### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,27 @@
+name: Dependencies
+on:
+  schedule:
+  - cron: "30 2 * * *"
+  workflow_dispatch:
+jobs:
+  updates:
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+
+    - name: Update dependencies
+      run: |
+        sudo apt-get update
+        sh scripts/update_dependencies.sh
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: "chore(deps): update dependencies.json"
+        branch: features/update-dependencies
+        title: Update APT packages
+        body: Updated dependencies.json
+        delete-branch: true
+        labels: dependencies
+        reviewers: jsirianni

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
 FROM ubuntu:20.04
 
-ARG systemd_version="245.4-4ubuntu3.7"
-ARG tzdata_version="2021a-0ubuntu0.20.04"
-ARG certificates_version="20210119~20.04.1"
+COPY dependencies.json /tmp/dependencies.json
 
-
-RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get install -y \
-        --no-install-recommends \
-        "ca-certificates=${certificates_version}" \
-        "systemd=${systemd_version}" \
-        "tzdata=${tzdata_version}" && \
-    rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/dependencies.json | xargs apt-get install -y --no-install-recommends \
+    && rm /tmp/dependencies.json \
+    && apt-get purge -y jq \
+    && apt-get clean

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,5 @@
+{
+    "ca-certificates": "20210119~20.04.1",
+    "systemd": "245.4-4ubuntu3.7",
+    "tzdata": "2021a-0ubuntu0.20.04"
+}

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+JSON=$( cat dependencies.json )
+
+for PACKAGE in $( echo "${JSON}" | jq -r 'keys | .[]' ); do
+	VERSION=$( apt-cache policy "${PACKAGE}" | grep -oP '(?<=Candidate:\s)(.+)' )
+	JSON=$( echo "${JSON}" | jq '.[$package] = $version' --arg package "${PACKAGE}" --arg version "${VERSION}" )
+done
+
+echo "${JSON}" | python -m json.tool > dependencies.json


### PR DESCRIPTION
- Moved package version to dependencies.json file
- Added workflow for updating dependencies.json (and opening a pull request)

You can build and test the image locally: 
```bash
docker build . -t stanza-base
docker run -d --name stanza-test --entrypoint=/bin/sleep stanza-base 3600
cinc-auditor exec test/integration.rb -t docker://stanza-test
```
```bash
Profile: tests from test/integration.rb (tests from test.integration.rb)
Version: (not specified)
Target:  docker://312d9734b9fc07124a738ea1c066a9afb2b58e9184ebf14925703c4ba0fc11a9

  System Package systemd
     ✔  is expected to be installed
     ✔  version is expected to eq "245.4-4ubuntu3.7"
  System Package tzdata
     ✔  is expected to be installed
     ✔  version is expected to eq "2021a-0ubuntu0.20.04"
  System Package ca-certificates
     ✔  is expected to be installed
     ✔  version is expected to eq "20210119~20.04.1"

Test Summary: 6 successful, 0 failures, 0 skipped
```

Inspiration: https://github.com/dependabot/dependabot-core/issues/2129

The next step would be to generate the test file from the dependencies.json.